### PR TITLE
Add *.tpp as a C++ extension

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -15,7 +15,8 @@ module Rouge
                 '*.c++', '*.h++',
                 '*.cc',  '*.hh',
                 '*.cxx', '*.hxx',
-                '*.pde', '*.ino'
+                '*.pde', '*.ino',
+                '*.tpp'
       mimetypes 'text/x-c++hdr', 'text/x-c++src'
 
       def self.keywords


### PR DESCRIPTION
*.tpp files are used to store template implementation.
This is advised for example in [these guidelines](http://web.mst.edu/~cpp/cpp_coding_standard_v1_1.pdf).